### PR TITLE
Strict TypeScript compiler and allow debugging

### DIFF
--- a/src/middleware/error-handler.ts
+++ b/src/middleware/error-handler.ts
@@ -4,9 +4,9 @@ import winstonLogger from "../utils/winston-logger";
 
 export const errorHandler = (
   err: Error,
-  req: Request,
+  _: Request,
   res: Response,
-  next: NextFunction
+  _next: NextFunction
 ) => {
   winstonLogger.error(`Error: ${err.message}\n${err.stack}`);
 
@@ -14,7 +14,7 @@ export const errorHandler = (
     return res.status(err.statusCode).send({ errors: err.serializeErrors() });
   }
 
-  res.status(500).send({
+  return res.status(500).send({
     errors: [{ message: "Internal server error. Please retry again later." }],
   });
 };

--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import winstonLogger from "../utils/winston-logger";
 
-export function logger(req: Request, res: Response, next: NextFunction) {
+export function logger(req: Request, _: Response, next: NextFunction) {
   winstonLogger.info(`${req.method} ${req.originalUrl}`);
   next();
 }

--- a/src/middleware/validation-middleware.ts
+++ b/src/middleware/validation-middleware.ts
@@ -4,7 +4,7 @@ import { RequestValidationError } from "../errors/request-validation-error";
 import "express-async-errors";
 
 export function validationMiddleware(validators: any[]) {
-  return async (req: Request, res: Response, next: NextFunction) => {
+  return async (req: Request, _: Response, next: NextFunction) => {
     for (const validator of validators) {
       await validator.run(req);
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
     "rootDir": "./src",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
     "strict": true,
     "skipLibCheck": true,
     "resolveJsonModule": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
+    "sourceMap": true,
     "strict": true,
     "skipLibCheck": true,
     "resolveJsonModule": true


### PR DESCRIPTION
Added strict TypeScript options:

1. "noUnusedLocals": true - This option ensures that the compiler raises an error for any unused local variables in the code.
2. "noUnusedParameters": true - This option ensures that the compiler raises an error for any unused function parameters.
3. "noImplicitReturns": true - This option ensures that the compiler raises an error for any code path that does not explicitly return a value in a function.